### PR TITLE
To ensure conformance with (regex ^\w+(\.\w+)*$). (https://packaging.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ options:
 
 `zenoh-cli` comes with a plugin system for easily extending it with custom encoders and decoders (codecs) for the data values. The plugin system makes use of the entrypoints provided by setuptools, see [here](https://setuptools.pypa.io/en/latest/userguide/entry_point.html) for details. `zenoh-cli` gather plugins from two custom "groups":
 
-* `zenoh-cli.codecs.encoders`
-* `zenoh-cli.codecs.decoders`
+* `zenoh_cli.codecs.encoders`
+* `zenoh_cli.codecs.decoders`
 
 For an example, see [example_plugin](./example_plugin/)

--- a/example_plugin/setup.py
+++ b/example_plugin/setup.py
@@ -4,11 +4,11 @@ setup(
     name="example-plugin",
     py_modules=["example"],
     entry_points={
-        "zenoh-cli.codecs.encoders": [
+        "zenoh_cli.codecs.encoders": [
             "example1 = example:example_encoder_1",
             "example2 = example:example_encoder_2",
         ],
-        "zenoh-cli.codecs.decoders": [
+        "zenoh_cli.codecs.decoders": [
             "example1 = example:example_decoder_1",
             "example2 = example:example_decoder_2",
         ],

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="zenoh-cli",
-    version="0.4.1",
+    version="0.5.0",
     license="Apache License 2.0",
     description="CLI for Zenoh",
     long_description=read("README.md"),

--- a/zenoh_cli.py
+++ b/zenoh_cli.py
@@ -190,7 +190,12 @@ def network(
     me = str(session.info().zid())
 
     nx.draw_networkx(
-        graph, pos, nodelist=routers, node_color="#1f77b4", with_labels=False
+        graph,
+        pos,
+        nodelist=routers,
+        node_color="#1f77b4",
+        node_size=500,
+        with_labels=False,
     )
     nx.draw_networkx(
         graph, pos, nodelist=peers, node_color="#ff7f0e", with_labels=False
@@ -199,6 +204,10 @@ def network(
         graph, pos, nodelist=clients, node_color="#17becf", with_labels=False
     )
     nx.draw_networkx(graph, pos, nodelist=[me], node_color="#d62728", with_labels=False)
+
+    # Node labels
+    labels = {zid: zid[:5] for zid in nx.nodes(graph)}
+    nx.draw_networkx_labels(graph, pos, labels, font_color="y")
 
     # Edges
     nx.draw_networkx_edge_labels(
@@ -283,8 +292,8 @@ def gather_plugins():
         )
         from importlib_metadata import entry_points
 
-    encoder_plugins = entry_points(group="zenoh-cli.codecs.encoders")
-    decoder_plugins = entry_points(group="zenoh-cli.codecs.decoders")
+    encoder_plugins = entry_points(group="zenoh_cli.codecs.encoders")
+    decoder_plugins = entry_points(group="zenoh_cli.codecs.decoders")
 
     plugin_encoders = {}
     plugin_decoders = {}
@@ -355,7 +364,7 @@ def main():
     info_parser = subparsers.add_parser("info")
     info_parser.set_defaults(func=info)
 
-    ## Graph subcommand
+    ## Network subcommand
     network_parser = subparsers.add_parser("network")
     network_parser.set_defaults(func=network)
 


### PR DESCRIPTION
…python.org/en/latest/specifications/entry-points/#data-model).

Dashes in group name does not work with python < 3.11 due to usage of a vendored version of pkg_resources in pip.